### PR TITLE
Add isValid(url)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Once you have your Swift package set up, adding SwiftUIFormHelper as a dependenc
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/jeroenzonneveld/SwiftUIFormHelper", .upToNextMajor(from: "1.2.0"))
+    .package(url: "https://github.com/jeroenzonneveld/SwiftUIFormHelper", .upToNextMajor(from: "1.3.0"))
 ]
 ```
 
@@ -47,9 +47,14 @@ Form {
 
 ### Form Validator
 
-Validate input from fields. Currenlty supported:
-- email
-- phoneNumber
+Validate input from fields. Currently supported:
+- isNotEmpty
+- isEmpty
+- hasMinimium(characters)
+- isValid
+    - email
+    - phoneNumber
+    - url
 
 ```swift
 import SwiftUIFormHelper
@@ -59,4 +64,7 @@ FormValidator.isValid(email: email)
 
 let phoneNumber = "+31612345678"
 FormValidator.isValid(phoneNumber: phoneNumber)
+
+let url = "apple.com"
+FormValidator.isValid(url: url)
 ```

--- a/Source/FormValidator.swift
+++ b/Source/FormValidator.swift
@@ -33,4 +33,11 @@ public class FormValidator {
         
         return phonePredicate.evaluate(with: phoneNumber)
     }
+    
+    public static func isValid(url: String) -> Bool {
+        let regex = "^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$"
+        let urlPredicate = NSPredicate(format: "SELF MATCHES %@", regex)
+        
+        return urlPredicate.evaluate(with: url)
+    }
 }


### PR DESCRIPTION
RegEx should match most URLs while not being too complex. Test here: https://www.regextester.com/93652

Also add these methods to docs:
- isNotEmpty
- isEmpty
- hasMinimium(characters)

And update 1.2.0 to 1.3.0 in Installation, as I guess this ends up being 1.3.0.