### PR TITLE
Fix Swift error in Regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Once you have your Swift package set up, adding SwiftUIFormHelper as a dependenc
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/jeroenzonneveld/SwiftUIFormHelper", .upToNextMajor(from: "1.3.0"))
+    .package(url: "https://github.com/jeroenzonneveld/SwiftUIFormHelper", .upToNextMajor(from: "1.3.1"))
 ]
 ```
 

--- a/Source/FormValidator.swift
+++ b/Source/FormValidator.swift
@@ -35,9 +35,11 @@ public class FormValidator {
     }
     
     public static func isValid(url: String) -> Bool {
-        let regex = "((?:http|https)://)?(?:www\\.)?[\\w\\d\\-_]+\\.\\w{2,3}(\\.\\w{2})?(/(?<=/)(?:[\\w\\d\\-./_]+)?)?"
-        let urlPredicate = NSPredicate(format: "SELF MATCHES %@", regex)
-        
-        return urlPredicate.evaluate(with: url)
+        let detector = try! NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
+        if let match = detector.firstMatch(in: self, options: [], range: NSRange(location: 0, length: self.utf16.count)) {
+            return match.range.length == self.utf16.count // it is a link if the match covers the whole string
+        } else {
+            return false
+        }
     }
 }

--- a/Source/FormValidator.swift
+++ b/Source/FormValidator.swift
@@ -36,8 +36,8 @@ public class FormValidator {
     
     public static func isValid(url: String) -> Bool {
         let detector = try! NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
-        if let match = detector.firstMatch(in: self, options: [], range: NSRange(location: 0, length: self.utf16.count)) {
-            return match.range.length == self.utf16.count // it is a link if the match covers the whole string
+        if let match = detector.firstMatch(in: url, options: [], range: NSRange(location: 0, length: url.count)) {
+            return match.range.length == url.count // it is a link if the match covers the whole string
         } else {
             return false
         }

--- a/Source/FormValidator.swift
+++ b/Source/FormValidator.swift
@@ -35,7 +35,7 @@ public class FormValidator {
     }
     
     public static func isValid(url: String) -> Bool {
-        let regex = "^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$"
+        let regex = "((?:http|https)://)?(?:www\\.)?[\\w\\d\\-_]+\\.\\w{2,3}(\\.\\w{2})?(/(?<=/)(?:[\\w\\d\\-./_]+)?)?"
         let urlPredicate = NSPredicate(format: "SELF MATCHES %@", regex)
         
         return urlPredicate.evaluate(with: url)


### PR DESCRIPTION
Apparently the RegEx wasn't working in Swift (for some reason). 

Using NSDataDetector seems to work better & I think is a more elegant in Swift.